### PR TITLE
:bug: - Fixing token expiry verifying

### DIFF
--- a/src/routes/middlewares/auth.js
+++ b/src/routes/middlewares/auth.js
@@ -13,22 +13,18 @@ const verifyToken = (req, res, next) => {
 
   try {
     const decrypted = jwt.verify(token, process.env.TOKEN_KEY);
-    const expiry = decrypted.exp;
-    const now = new Date();
-    const expired = now.getTime() > expiry * 1000;
-
-    if (expired) {
-      res.status(401);
-      return res.json({
-        message: 'Token expired',
-      });
-    }
-
+  
     req.session.user = decrypted;
 
     next();
 
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      res.status(401);
+      return res.json({
+        message: 'Token expired',
+      });
+    }
     res.status(401);
     res.json({
       message: 'Token invalid',


### PR DESCRIPTION
Crec que amb això se soluciona el bug que feia que es pogués accedir amb un token caducat.

El tema és que el mètode jwt si no se li passa un callback i el token està caducat directament tira un error i no l'estavem caçant, he estat fent proves i crec que així ja es soluciona, ja em direu... 
